### PR TITLE
Fix unit tests following upstream change in QGIS API behavior

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ install:
   - docker exec -it qgis-testing-environment sh -c "ln -s /tests_directory/processing_r /root/.local/share/QGIS/QGIS3/profiles/default/python/plugins/processing_r"
 
   - docker exec -it qgis-testing-environment sh -c "pip3 install -r /tests_directory/REQUIREMENTS_TESTING.txt"
+  - docker exec -it qgis-testing-environment sh -c "apt-get update"
   - docker exec -it qgis-testing-environment sh -c "apt-get install -y r-base"
 
 script:

--- a/processing_r/processing/algorithm.py
+++ b/processing_r/processing/algorithm.py
@@ -20,7 +20,8 @@
 import os
 import json
 
-from qgis.core import (QgsProcessing,
+from qgis.core import (Qgis,
+                       QgsProcessing,
                        QgsProviderRegistry,
                        QgsProcessingAlgorithm,
                        QgsProcessingException,
@@ -374,6 +375,16 @@ class RAlgorithm(QgsProcessingAlgorithm):  # pylint: disable=too-many-public-met
         :param parameters: Parameters of the algorithm.
         :param context: Processing context
         """
+        if Qgis.QGIS_VERSION_INT >= 30900:
+            # requires qgis 3.10 or later!
+            ogr_data_path, layer_name = self.parameterAsCompatibleSourceLayerPathAndLayerName(parameters, name, context,
+                                                                                              QgsVectorFileWriter.supportedFormatExtensions(),
+                                                                                              feedback=feedback)
+            if layer_name:
+                return '{}=readOGR("{}",layer="{}")'.format(name, QDir.fromNativeSeparators(ogr_data_path), layer_name)
+
+            return '{}=readOGR("{}")'.format(name, QDir.fromNativeSeparators(ogr_data_path))
+
         ogr_data_path = self.parameterAsCompatibleSourceLayerPath(parameters, name, context,
                                                                   QgsVectorFileWriter.supportedFormatExtensions(),
                                                                   feedback=feedback)
@@ -394,12 +405,12 @@ class RAlgorithm(QgsProcessingAlgorithm):  # pylint: disable=too-many-public-met
             if not source_parts.get('path'):
                 is_ogr_disk_based_layer = False
             elif source_parts.get('layerId'):
-                # no support for directly reading layers by id in grass
+                # no support for directly reading layers by id in R
                 is_ogr_disk_based_layer = False
 
         if not is_ogr_disk_based_layer:
             # parameter is not a vector layer or not an OGR layer - try to convert to a source compatible with
-            # grass OGR inputs and extract selection if required
+            # R OGR inputs and extract selection if required
             path = QgsProcessingUtils.convertToCompatibleFormat(layer, False, variable_name,
                                                                 compatibleFormats=QgsVectorFileWriter.supportedFormatExtensions(),
                                                                 preferredFormat='gpkg',

--- a/processing_r/processing/algorithm.py
+++ b/processing_r/processing/algorithm.py
@@ -375,7 +375,7 @@ class RAlgorithm(QgsProcessingAlgorithm):  # pylint: disable=too-many-public-met
         :param parameters: Parameters of the algorithm.
         :param context: Processing context
         """
-        if Qgis.QGIS_VERSION_INT >= 30900:
+        if Qgis.QGIS_VERSION_INT >= 30900 and hasattr(self, 'parameterAsCompatibleSourceLayerPathAndLayerName'):
             # requires qgis 3.10 or later!
             ogr_data_path, layer_name = self.parameterAsCompatibleSourceLayerPathAndLayerName(parameters, name, context,
                                                                                               QgsVectorFileWriter.supportedFormatExtensions(),

--- a/processing_r/test/data/test_vectorin.rsx
+++ b/processing_r/test/data/test_vectorin.rsx
@@ -1,1 +1,2 @@
 ##Layer=vector
+##Layer2=vector

--- a/processing_r/test/utilities.py
+++ b/processing_r/test/utilities.py
@@ -76,7 +76,7 @@ def get_qgis_app(cleanup=True):
             debug_log_message)
 
         if cleanup:
-            import atexit
+            import atexit  # pylint: disable=import-outside-toplevel
 
             @atexit.register
             def exitQgis():  # pylint: disable=unused-variable


### PR DESCRIPTION
A bug fix in QGIS ~3.6 impacted the tests (and performance of R
provider) by forcing format conversion of multi-layer input files
(such as geopackage).

New API has been added upstream to avoid this forced conversion
for providers like R, but it's only available in QGIS 3.10 or later.

Update to use this new API when available, and fix failing unit
tests.