### PR TITLE
Don't generate r script twice

### DIFF
--- a/processing_r/processing/algorithm.py
+++ b/processing_r/processing/algorithm.py
@@ -313,9 +313,6 @@ class RAlgorithm(QgsProcessingAlgorithm):  # pylint: disable=too-many-public-met
                             'before running R scripts.'))
 
         feedback.pushInfo(self.tr('R execution commands'))
-        script_lines = self.build_r_script(parameters, context, feedback)
-        for line in script_lines:
-            feedback.pushCommandInfo(line)
 
         output = RUtils.execute_r_algorithm(self, parameters, context, feedback)
 

--- a/processing_r/processing/r_templates.py
+++ b/processing_r/processing/r_templates.py
@@ -365,7 +365,7 @@ class RTemplates:
         :param path: string. Path to search for packages and install there if missing.
         :return: string. R code to change path to package library.
         """
-        return '.libPaths({0})'.format(path)
+        return '.libPaths(\"{0}\")'.format(path.replace('\\', '/'))
 
     def set_option(self, option_name: str, value: str) -> str:
         """

--- a/processing_r/processing/utils.py
+++ b/processing_r/processing/utils.py
@@ -228,7 +228,12 @@ class RUtils:  # pylint: disable=too-many-public-methods
         Runs a prepared algorithm in R, and returns a list of the output received from R
         """
         # generate new R script file name in a temp folder
-        script_filename = RUtils.create_r_script_from_commands(alg.build_r_script(parameters, context, feedback))
+
+        script_lines = alg.build_r_script(parameters, context, feedback)
+        for line in script_lines:
+            feedback.pushCommandInfo(line)
+
+        script_filename = RUtils.create_r_script_from_commands(script_lines)
 
         # run commands
         command = [


### PR DESCRIPTION
Fixes incorrect error messages after alg execution when using temp paths, different temp paths showing in log vs what is actually executed