### PR TITLE
Fix output file destination value

### DIFF
--- a/processing_r/processing/algorithm.py
+++ b/processing_r/processing/algorithm.py
@@ -653,10 +653,12 @@ class RAlgorithm(QgsProcessingAlgorithm):  # pylint: disable=too-many-public-met
                 folder = self.parameterAsString(parameters, param.name(), context)
                 commands.append(self.r_templates.set_variable_string(param.name(),
                                                                      folder))
+                self.save_output_values = True
             elif isinstance(param, QgsProcessingParameterFileDestination):
                 filename = self.parameterAsFileOutput(parameters, param.name(), context)
                 commands.append(self.r_templates.set_variable_string(param.name(),
                                                                      filename))
+                self.save_output_values = True
 
         if self.show_plots:
             html_filename = self.parameterAsFileOutput(parameters, RAlgorithm.RPLOTS, context)

--- a/processing_r/test/data/test_multiout.rsx
+++ b/processing_r/test/data/test_multiout.rsx
@@ -1,8 +1,19 @@
 ##load_vector_using_rgdal
 ##Output=output vector
 ##OutputCSV=output table
+##OutputFile=output file csv
 ##OutputNum=output number
 ##OutputStr=output string
 
 OutputNum <- 4.5
 OutputStr <- "value"
+
+data <- read.table(header=TRUE, text='
+ subject sex size
+       1   M    7
+       2   F    NA
+       3   F    9
+       4   M   11
+ ')
+
+write.csv2(data, outputFile, row.names = FALSE, na ="")

--- a/processing_r/test/test_algorithm.py
+++ b/processing_r/test/test_algorithm.py
@@ -358,15 +358,19 @@ class AlgorithmTest(unittest.TestCase):
 
         context = QgsProcessingContext()
         feedback = QgsProcessingFeedback()
-        script = alg.build_export_commands({'Output': '/home/test/lines.shp', 'OutputCSV': '/home/test/tab.csv'},
+        script = alg.build_export_commands({'Output': '/home/test/lines.shp',
+                                            'OutputCSV': '/home/test/tab.csv',
+                                            'OutputFile': '/home/test/file.csv'},
                                            context, feedback)
 
         self.assertIn('writeOGR(Output, "/home/test/lines.shp", "lines", driver="ESRI Shapefile")', script)
         self.assertIn('write.csv(OutputCSV, "/home/test/tab.csv")', script)
-        self.assertTrue(script[2].startswith('cat("##OutputNum", file='), script[2])
-        self.assertTrue(script[3].startswith('cat(OutputNum, file='), script[3])
-        self.assertTrue(script[4].startswith('cat("##OutputStr", file='), script[4])
-        self.assertTrue(script[5].startswith('cat(OutputStr, file='), script[5])
+        self.assertTrue(script[2].startswith('cat("##OutputFile", file='), script[2])
+        self.assertTrue(script[3].startswith('cat(OutputFile, file='), script[3])
+        self.assertTrue(script[4].startswith('cat("##OutputNum", file='), script[4])
+        self.assertTrue(script[5].startswith('cat(OutputNum, file='), script[5])
+        self.assertTrue(script[6].startswith('cat("##OutputStr", file='), script[6])
+        self.assertTrue(script[7].startswith('cat(OutputStr, file='), script[7])
 
     def testEnums(self):
         """


### PR DESCRIPTION
For QgsProcessingParameterFileDestination and QgsProcessingParameterFolderDestination, the value provide to the script or by the script is not saved and provided to the user.

The commit fix it and test it.