### PR TITLE
Fix test qgis version

### DIFF
--- a/processing_r/test/test_algorithm.py
+++ b/processing_r/test/test_algorithm.py
@@ -398,7 +398,7 @@ class AlgorithmTest(unittest.TestCase):
         self.assertIn('Test help.', alg.shortHelpString())
 
         # param help
-        if Qgis.QGIS_VERSION_INT >= 31600:
+        if Qgis.QGIS_VERSION_INT >= 31604:
             polyg_param = alg.parameterDefinition('polyg')
             self.assertEqual(polyg_param.help(), 'A polygon layer')
 

--- a/processing_r/test_suite.py
+++ b/processing_r/test_suite.py
@@ -15,6 +15,7 @@ import unittest
 import tempfile
 from osgeo import gdal
 import qgis  # pylint: disable=unused-import
+from qgis.core import Qgis
 
 try:
     from pip import main as pipmain
@@ -40,6 +41,7 @@ def _run_tests(test_suite, package_name, with_coverage=False):
     print('########')
     print('%s tests has been discovered in %s' % (count, package_name))
     print('Python GDAL : %s' % gdal.VersionInfo('VERSION_NUM'))
+    print('QGIS version : {}'.format(Qgis.version()))
     print('########')
     if with_coverage:
         cov = coverage.Coverage(


### PR DESCRIPTION
Prints QGIS version in the test output and fix failing test by requiring QGIS version 31604.