### PR TITLE
Parameter metadata: add the capability to use parameter description

### DIFF
--- a/processing_r/processing/algorithm.py
+++ b/processing_r/processing/algorithm.py
@@ -207,10 +207,10 @@ class RAlgorithm(QgsProcessingAlgorithm):  # pylint: disable=too-many-public-met
             if line.startswith('##'):
                 try:
                     self.process_metadata_line(line)
-                except Exception:  # pylint: disable=broad-except
+                except Exception as e:  # pylint: disable=broad-except
                     self.add_error_message(
                         self.tr('This script has a syntax error.\n'
-                                'Problem with line: {0}').format(line)
+                                'Exception {1} with line: {0}').format(line, e)
                     )
             elif line.startswith('>'):
                 self.commands.append(line[1:])

--- a/processing_r/processing/algorithm.py
+++ b/processing_r/processing/algorithm.py
@@ -198,8 +198,10 @@ class RAlgorithm(QgsProcessingAlgorithm):  # pylint: disable=too-many-public-met
                 try:
                     self.process_metadata_line(line)
                 except Exception:  # pylint: disable=broad-except
-                    self.error = self.tr('This script has a syntax error.\n'
-                                         'Problem with line: {0}').format(line)
+                    self.add_error_message(
+                        self.tr('This script has a syntax error.\n'
+                                'Excepton with line: {0}').format(line)
+                    )
             elif line.startswith('>'):
                 self.commands.append(line[1:])
                 if not self.show_console_output:
@@ -281,6 +283,10 @@ class RAlgorithm(QgsProcessingAlgorithm):  # pylint: disable=too-many-public-met
         """
         Attempts to split a line into tokens
         """
+        if "|" in line and line.startswith("QgsProcessing"):
+            tokens = line.split("|")
+            return tokens[1], line
+
         tokens = line.split('=')
         return tokens[0], tokens[1]
 

--- a/processing_r/processing/algorithm.py
+++ b/processing_r/processing/algorithm.py
@@ -154,6 +154,16 @@ class RAlgorithm(QgsProcessingAlgorithm):  # pylint: disable=too-many-public-met
         """
         return self._group
 
+    def add_error_message(self, message):
+        """
+        Add error message to algorithme errors
+        """
+        if not self.error:
+            self.error = message
+        else:
+            self.error += '\n'
+            self.error += message
+
     def load_from_string(self):
         """
         Load the algorithm from a string
@@ -200,7 +210,7 @@ class RAlgorithm(QgsProcessingAlgorithm):  # pylint: disable=too-many-public-met
                 except Exception:  # pylint: disable=broad-except
                     self.add_error_message(
                         self.tr('This script has a syntax error.\n'
-                                'Excepton with line: {0}').format(line)
+                                'Problem with line: {0}').format(line)
                     )
             elif line.startswith('>'):
                 self.commands.append(line[1:])
@@ -298,9 +308,11 @@ class RAlgorithm(QgsProcessingAlgorithm):  # pylint: disable=too-many-public-met
         description = RUtils.create_descriptive_name(value)
 
         if not RUtils.is_valid_r_variable(value):
-            self.error = self.tr('This script has a syntax error in variable name.\n'
-                                 '"{1}" is not a valid variable name in R.'
-                                 'Problem with line: {0}').format(line, value)
+            self.add_error_message(
+                self.tr('This script has a syntax error in variable name.\n'
+                        '"{1}" is not a valid variable name in R.'
+                        'Problem with line: {0}').format(line, value)
+            )
 
         output = create_output_from_string(line)
         if output is not None:
@@ -323,8 +335,10 @@ class RAlgorithm(QgsProcessingAlgorithm):  # pylint: disable=too-many-public-met
 
                 self.addParameter(param)
             else:
-                self.error = self.tr('This script has a syntax error.\n'
-                                     'Problem with line: {0}').format(line)
+                self.add_error_message(
+                    self.tr('This script has a syntax error.\n'
+                            'Problem with line: {0}').format(line)
+                )
 
     def canExecute(self):
         """

--- a/processing_r/processing/parameters.py
+++ b/processing_r/processing/parameters.py
@@ -26,9 +26,7 @@ def create_parameter_from_string(s: str):
     """
     Tries to create an algorithm parameter from a line string
     """
-    if "|" in s and s.startswith("##QgsProcessingParameter"):
-        s = s[2:]
-    else:
+    if not ("|" in s and s.startswith("QgsProcessingParameter")):
         s = RUtils.upgrade_parameter_line(s)
 
         # this is necessary to remove the otherwise unknown keyword

--- a/processing_r/test/data/test_algorithm_4.rsx
+++ b/processing_r/test/data/test_algorithm_4.rsx
@@ -1,0 +1,45 @@
+##my test=name
+##my group=group
+
+##QgsProcessingParameterRasterLayer|in_raster|Input raster
+##QgsProcessingParameterFeatureSource|in_vector|Input vector
+##QgsProcessingParameterField|in_field|Input field|None|in_vector
+##QgsProcessingParameterExtent|in_extent|Input extent
+##QgsProcessingParameterCrs|in_crs|Input CRS
+##QgsProcessingParameterString|in_string|Input String
+##QgsProcessingParameterNumber|in_number|Input number
+##QgsProcessingParameterEnum|in_enum|Input enum
+##QgsProcessingParameterBoolean|in_bool|Input boolean
+
+##QgsProcessingParameterFile|in_file|Input file
+##QgsProcessingParameterFile|in_folder|Input folder|1
+##QgsProcessingParameterFile|in_gpkg|Input gpkg|0|gpkg
+##QgsProcessingParameterFile|in_img|Input img|0|png|None|False|PNG Files (*.png);; JPG Files (*.jpg *.jpeg)
+
+##QgsProcessingParameterVectorDestination|param_vector_dest|Vector destination
+##QgsProcessingParameterVectorDestination|param_vector_point_dest|Vector destination point|0
+##QgsProcessingParameterVectorDestination|param_vector_line_dest|Vector destination line|1
+##QgsProcessingParameterVectorDestination|param_vector_polygon_dest|Vector destination polygon|2
+##QgsProcessingParameterVectorDestination|param_table_dest|Vector destination table|5
+##QgsProcessingParameterRasterDestination|param_raster_dest|Raster destination
+
+##QgsProcessingParameterFolderDestination|param_folder_dest|Folder destination
+##QgsProcessingParameterFileDestination|param_file_dest|File destination
+##QgsProcessingParameterFileDestination|param_html_dest|HTML File destination|HTML Files (*.html)
+##QgsProcessingParameterFileDestination|param_csv_dest|CSV File destination|CSV Files (*.csv)
+##QgsProcessingParameterFileDestination|param_img_dest|Img File destination|PNG Files (*.png);; JPG Files (*.jpg *.jpeg)
+
+##out_vector=output vector noprompt
+##out_table=output table noprompt
+##out_raster=output raster noprompt
+##out_number=output number
+##out_string=output string
+##out_layer=output layer
+##out_folder=output folder noprompt
+##out_html=output html noprompt
+##out_file=output file noprompt
+##out_csv=output file csv noprompt
+
+library(sp)
+i <- 1
+

--- a/processing_r/test/test_algorithm.py
+++ b/processing_r/test/test_algorithm.py
@@ -18,6 +18,7 @@ import unittest
 import os
 from qgis.core import (Qgis,
                        QgsProcessingParameterNumber,
+                       QgsProcessingParameterFile,
                        QgsProcessing,
                        QgsProcessingContext,
                        QgsProcessingFeedback,
@@ -145,6 +146,7 @@ class AlgorithmTest(unittest.TestCase):
         self.assertEqual(csv_dest_param.type(), 'fileDestination')
         self.assertEqual(csv_dest_param.defaultFileExtension(), 'csv')
 
+        # test display_name
         alg = RAlgorithm(description_file=os.path.join(test_data_path, 'test_algorithm_3.rsx'))
         alg.initAlgorithm()
         self.assertFalse(alg.error)
@@ -152,6 +154,87 @@ class AlgorithmTest(unittest.TestCase):
         self.assertEqual(alg.displayName(), 'the algo title')
         self.assertEqual(alg.group(), 'my group')
         self.assertEqual(alg.groupId(), 'my group')
+
+        # test that inputs are defined as parameter description
+        alg = RAlgorithm(description_file=os.path.join(test_data_path, 'test_algorithm_4.rsx'))
+        alg.initAlgorithm()
+        self.assertFalse(alg.error)
+        self.assertEqual(alg.name(), 'mytest')
+        self.assertEqual(alg.displayName(), 'my test')
+        self.assertEqual(alg.group(), 'my group')
+        self.assertEqual(alg.groupId(), 'my group')
+
+        raster_param = alg.parameterDefinition('in_raster')
+        self.assertEqual(raster_param.type(), 'raster')
+        vector_param = alg.parameterDefinition('in_vector')
+        self.assertEqual(vector_param.type(), 'source')
+        field_param = alg.parameterDefinition('in_field')
+        self.assertEqual(field_param.type(), 'field')
+        self.assertEqual(field_param.parentLayerParameterName(), 'in_vector')
+        extent_param = alg.parameterDefinition('in_extent')
+        self.assertEqual(extent_param.type(), 'extent')
+        crs_param = alg.parameterDefinition('in_crs')
+        self.assertEqual(crs_param.type(), 'crs')
+        string_param = alg.parameterDefinition('in_string')
+        self.assertEqual(string_param.type(), 'string')
+        number_param = alg.parameterDefinition('in_number')
+        self.assertEqual(number_param.type(), 'number')
+        self.assertEqual(number_param.dataType(), QgsProcessingParameterNumber.Integer)
+        enum_param = alg.parameterDefinition('in_enum')
+        self.assertEqual(enum_param.type(), 'enum')
+        bool_param = alg.parameterDefinition('in_bool')
+        self.assertEqual(bool_param.type(), 'boolean')
+
+        file_param = alg.parameterDefinition('in_file')
+        self.assertEqual(file_param.type(), 'file')
+        self.assertEqual(file_param.behavior(), QgsProcessingParameterFile.File)
+        folder_param = alg.parameterDefinition('in_folder')
+        self.assertEqual(folder_param.type(), 'file')
+        self.assertEqual(folder_param.behavior(), QgsProcessingParameterFile.Folder)
+        gpkg_param = alg.parameterDefinition('in_gpkg')
+        self.assertEqual(gpkg_param.type(), 'file')
+        self.assertEqual(gpkg_param.behavior(), QgsProcessingParameterFile.File)
+        self.assertEqual(gpkg_param.extension(), 'gpkg')
+        img_param = alg.parameterDefinition('in_img')
+        self.assertEqual(img_param.type(), 'file')
+        self.assertEqual(img_param.behavior(), QgsProcessingParameterFile.File)
+        self.assertEqual(img_param.extension(), '')
+        self.assertEqual(img_param.fileFilter(), 'PNG Files (*.png);; JPG Files (*.jpg *.jpeg)')
+
+        vector_dest_param = alg.parameterDefinition('param_vector_dest')
+        self.assertEqual(vector_dest_param.type(), 'vectorDestination')
+        self.assertEqual(vector_dest_param.dataType(), QgsProcessing.TypeVectorAnyGeometry)
+        vector_dest_param = alg.parameterDefinition('param_vector_point_dest')
+        self.assertEqual(vector_dest_param.type(), 'vectorDestination')
+        self.assertEqual(vector_dest_param.dataType(), QgsProcessing.TypeVectorPoint)
+        vector_dest_param = alg.parameterDefinition('param_vector_line_dest')
+        self.assertEqual(vector_dest_param.type(), 'vectorDestination')
+        self.assertEqual(vector_dest_param.dataType(), QgsProcessing.TypeVectorLine)
+        vector_dest_param = alg.parameterDefinition('param_vector_polygon_dest')
+        self.assertEqual(vector_dest_param.type(), 'vectorDestination')
+        self.assertEqual(vector_dest_param.dataType(), QgsProcessing.TypeVectorPolygon)
+        table_dest_param = alg.parameterDefinition('param_table_dest')
+        self.assertEqual(table_dest_param.type(), 'vectorDestination')
+        self.assertEqual(table_dest_param.dataType(), QgsProcessing.TypeVector)
+        raster_dest_param = alg.parameterDefinition('param_raster_dest')
+        self.assertEqual(raster_dest_param.type(), 'rasterDestination')
+
+        folder_dest_param = alg.parameterDefinition('param_folder_dest')
+        self.assertEqual(folder_dest_param.type(), 'folderDestination')
+        file_dest_param = alg.parameterDefinition('param_file_dest')
+        self.assertEqual(file_dest_param.type(), 'fileDestination')
+        html_dest_param = alg.parameterDefinition('param_html_dest')
+        self.assertEqual(html_dest_param.type(), 'fileDestination')
+        self.assertEqual(html_dest_param.fileFilter(), 'HTML Files (*.html)')
+        self.assertEqual(html_dest_param.defaultFileExtension(), 'html')
+        csv_dest_param = alg.parameterDefinition('param_csv_dest')
+        self.assertEqual(csv_dest_param.type(), 'fileDestination')
+        self.assertEqual(csv_dest_param.fileFilter(), 'CSV Files (*.csv)')
+        self.assertEqual(csv_dest_param.defaultFileExtension(), 'csv')
+        img_dest_param = alg.parameterDefinition('param_img_dest')
+        self.assertEqual(img_dest_param.type(), 'fileDestination')
+        self.assertEqual(img_dest_param.fileFilter(), 'PNG Files (*.png);; JPG Files (*.jpg *.jpeg)')
+        self.assertEqual(img_dest_param.defaultFileExtension(), 'png')
 
     def testBadAlgorithm(self):
         """

--- a/website/pages/script-syntax.md
+++ b/website/pages/script-syntax.md
@@ -62,23 +62,72 @@ The syntax is `##var_enum_string=enum literal a;b;c`. The important part here is
 
 #### QGIS definitions used in description files
 
-The inputs to R script are specified as: `QgsProcessingParameter|name|description|defaultValue|other_parameters_separated_by_pipe`.
+
+The inputs to R script are specified as: `QgsProcessingParameter|name|description|other_parameters_separated_by_pipe`.
 The _other_ parameter_ separated_ by_ pipe_ can contain the `QgsProcessingParameter` specific parameters.
-This metdata line is based on the QGIS definitions used in description file used by GRASS7, SAGA and others providers.
+This metadata line is based on the QGIS definitions used in description file used by GRASS7, SAGA and others providers.
 
 So the inputs can look like this:
 
-`##QgsProcessingParameterFeatureSource|INPUT|Points|0|None|False` specifies that there will be varaible `INPUT` that will be a vector.
+`##QgsProcessingParameterFeatureSource|INPUT|Vector layer` specifies that there will be variable `INPUT` that will be a vector.
 
-`##QgsProcessingParameterField|FIELDS|Attributes|None|INPUT|-1|False|False` specifies taht there will be varaible `FIELDS` that will be a field index.
+`##QgsProcessingParameterField|FIELDS|Attributes|None|INPUT|-1|False|False` specifies that there will be variable `FIELDS` that will be a field index.
 
-`##QgsProcessingParameterRasterLayer|INPUT|Grid|None|False` specifies that there will be varaible `INPUT` that will be a raster.
+`##QgsProcessingParameterRasterLayer|INPUT|Grid` specifies that there will be variable `INPUT` that will be a raster.
 
-`##QgsProcessingParameterNumber|SIZE|Aggregation Size|QgsProcessingParameterNumber.Integer|3|False|None|None` specifies that there will be variable `Size` that will be numeric, and a default value for `Size` will be `3`.
+`##QgsProcessingParameterNumber|SIZE|Aggregation Size|QgsProcessingParameterNumber.Integer|10` specifies that there will be variable `Size` that will be numeric, and a default value for `Size` will be `10`.
 
 `##QgsProcessingParameterEnum|METHOD|Method|[0] Sum;[1] Min;[2] Max` specifies that there will be variable `METHOD` that will be a value provided under `[]`.
 
 `##QgsProcessingParameterVectorDestination|OUTPUT|Result` specifies that there will be variable `OUTPUT` that will be the destination file.
+
+
+##### Feature source
+
+QgsProcessingParameterFeatureSource|name|description|geometry type|default value|optional
+* _name_ is mandatory
+* _description_ is mandatory
+* _geometry type_ is optional and the default value is `-1` for any geometry, the available values are `0` for point, `1` for line, `2` for polygon, `5` for table
+* _default value_ is optional and the default value is `None`
+* _optional_ is optional and the default value is `False`
+
+`##QgsProcessingParameterFeatureSource|INPUT|Points|0` specifies that there will be variable `INPUT` that will be a vector point layer.
+
+`##QgsProcessingParameterFeatureSource|INPUT|Lines|1` specifies that there will be variable `INPUT` that will be a vector line layer.
+
+`##QgsProcessingParameterFeatureSource|INPUT|Polygons|2` specifies that there will be variable `INPUT` that will be a vector polygon layer.
+
+`##QgsProcessingParameterFeatureSource|INPUT|Table|5` specifies that there will be variable `INPUT` that will be a vector layer to provide table.
+
+`##QgsProcessingParameterFeatureSource|INPUT|Optional layer|-1|None|True` specifies that there will be variable `INPUT` that will be an optional vector layer.
+
+##### Raster layer
+
+QgsProcessingParameterRasterLayer|name|description|default value|optional
+* _name_ is mandatory
+* _description_ is mandatory
+* _default value_ is optional and the default value is `None`
+* _optional_ is optional and the default value is `False`
+
+##### File or folder parameter
+
+QgsProcessingParameterFile|name|description|behavior|extension|default value|optional|file filter
+* _name_ is mandatory
+* _description_ is mandatory
+* _behavior_ is optional and the default value is `0` for file, `1` is for folder input parameter
+* _extension_ is optional and specifies a file extension associated with the parameter (e.g. `html`). Use _file filter_ for a more flexible approach which allows for multiple file extensions. if _file filter_ is specified it takes precedence and _extension_ is emptied.
+* _default value_ is optional and the default value is `None`
+* _optional_ is optional and the default value is `False`
+* _file filter_ is optional and specifies the available file extensions associted sith the parameter (e.g. `PNG Files (*.png);; JPG Files (*.jpg *.jpeg)`)
+
+`##QgsProcessingParameterFile|in_file|Input file` specifies that there will be variable `in_file` that will be any file.
+
+`##QgsProcessingParameterFile|in_folder|Input folder|1` specifies that there will be variable `in_folder` that will be a folder.
+
+`##QgsProcessingParameterFile|in_gpkg|Input gpkg|0|gpkg` specifies that there will be variable `in_gpkg` that will be gpkg file.
+
+`##QgsProcessingParameterFile|in_img|Input img|0|png|None|False|PNG Files (*.png);; JPG Files (*.jpg *.jpeg)`  specifies that there will be variable `in_img` that will be an image PNG or JPG.
+
 
 ### Outputs
 

--- a/website/pages/script-syntax.md
+++ b/website/pages/script-syntax.md
@@ -35,7 +35,7 @@ Several metadata lines define the general behaviour of the script.
 
 ### Inputs
 
-#### QGIS Script code description
+#### Simple specification
 
 The inputs to R script are specified as: `variable_name=variable_type [default_value/from_variable]`. This metadata line also specifies how tool UI will look in QGIS, as inputs are one section of the tool UI. In this specification _variable_name_ is the name of the variable used in R script, _variable_type_ is a type of input variable from possible input types (vector, raster, table, number, string, boolean, Field).
 This metadata line is based on the QGIS parameter `asScriptCode` / `fromScriptCode` string definition.
@@ -60,7 +60,7 @@ The approach described above works well for a wide range of applications but for
 
 The syntax is `##var_enum_string=enum literal a;b;c`. The important part here is the keyword `literal` (or more precisely `enum literal`) which specifies that the value from the select box to `var_enum_string` should be passed as a string. So if `b` is selected, then the value of `var_enum_string` will be `"a"`.
 
-#### QGIS definitions used in description files
+#### Advanced specification
 
 
 The inputs to R script are specified as: `QgsProcessingParameter|name|description|other_parameters_separated_by_pipe`.


### PR DESCRIPTION
The default inputs to R script are based on the QGIS parameter `asScriptCode` / `fromScriptCode` string definition.

QGIS also provide an other way to describe processing parameters used in GRASS7, SAGA and other processing providers.
We propose to reuse this capability. The metadata line looks like `QgsProcessingParameter|name|description|other_parameters_separated_by_pipe`.

The inputs can look like this:

`##QgsProcessingParameterFeatureSource|INPUT|Vector layer` specifies that there will be variable `INPUT` that will be a vector.

`##QgsProcessingParameterField|FIELDS|Attributes|None|INPUT|-1|False|False` specifies that there will be variable `FIELDS` that will be a field index.

`##QgsProcessingParameterRasterLayer|INPUT|Grid` specifies that there will be variable `INPUT` that will be a raster.

`##QgsProcessingParameterNumber|SIZE|Aggregation Size|QgsProcessingParameterNumber.Integer|10` specifies that there will be variable `Size` that will be numeric, and a default value for `Size` will be `10`.

`##QgsProcessingParameterEnum|METHOD|Method|[0] Sum;[1] Min;[2] Max` specifies that there will be variable `METHOD` that will be a value provided under `[]`.

`##QgsProcessingParameterVectorDestination|OUTPUT|Result` specifies that there will be variable `OUTPUT` that will be the destination vector layer.