### PR TITLE
Parameters description from lines within R script

### DIFF
--- a/processing_r/processing/algorithm.py
+++ b/processing_r/processing/algorithm.py
@@ -209,8 +209,12 @@ class RAlgorithm(QgsProcessingAlgorithm):  # pylint: disable=too-many-public-met
             # ordering for inline_help uses
             tmp = []
             for subs in ["#'", "##"]:
-                [tmp.append(line) for line in lines if subs in line]
-            [tmp.append(l) for l in lines if l not in tmp]
+                for line in lines:
+                    if subs in line:
+                        tmp.append(line)
+            for line in lines:
+                if line not in tmp:
+                    tmp.append(line)
             lines = tmp
         self.parse_script(iter(lines))
 

--- a/processing_r/processing/algorithm.py
+++ b/processing_r/processing/algorithm.py
@@ -210,7 +210,7 @@ class RAlgorithm(QgsProcessingAlgorithm):  # pylint: disable=too-many-public-met
             tmp = []
             for subs in ["#'", "##"]:
                 for line in lines:
-                    if subs in line:
+                    if line.startswith(subs):
                         tmp.append(line)
             for line in lines:
                 if line not in tmp:

--- a/processing_r/processing/algorithm.py
+++ b/processing_r/processing/algorithm.py
@@ -106,6 +106,7 @@ class RAlgorithm(QgsProcessingAlgorithm):  # pylint: disable=too-many-public-met
         self.output_values_filename = ''
         self.results = {}
         self.descriptions = None
+        self.inline_help = None
         if self.script is not None:
             self.load_from_string()
         if self.description_file is not None:
@@ -205,6 +206,12 @@ class RAlgorithm(QgsProcessingAlgorithm):  # pylint: disable=too-many-public-met
 
         with open(self.description_file, 'r', encoding='utf8') as f:
             lines = [line.strip() for line in f]
+            # ordering for inline_help uses
+            tmp = []
+            for subs in ["#'", "##"]:
+                [tmp.append(line) for line in lines if subs in line]
+            [tmp.append(l) for l in lines if l not in tmp]
+            lines = tmp
         self.parse_script(iter(lines))
 
     def parse_script(self, lines):
@@ -227,6 +234,14 @@ class RAlgorithm(QgsProcessingAlgorithm):  # pylint: disable=too-many-public-met
                     self.add_error_message(
                         self.tr('This script has a syntax error.\n'
                                 'Exception {1} with line: {0}').format(line, e)
+                    )
+            elif line.startswith("#'"):
+                try:
+                    self.process_help_line(line)
+                except Exception as e:  # pylint: disable=broad-except
+                    self.add_error_message(
+                        self.tr('This script has a syntax error.\n'
+                                'Exception {1} with help line: {0}...').format(line[0:50], e)
                     )
             elif line.startswith('>'):
                 self.commands.append(line[1:])
@@ -308,6 +323,23 @@ class RAlgorithm(QgsProcessingAlgorithm):  # pylint: disable=too-many-public-met
 
         self.process_parameter_line(line)
 
+    def process_help_line(self, line):  # pylint: disable=too-many-return-statements
+        """
+        Processes a "help" (#') line
+        """
+        line = line.replace("#'", "")
+        key, value = line.split(":", 1)
+        if self.inline_help is None:
+            help_dict = {}
+        else:
+            help_dict = self.inline_help
+        if key.strip() == "":
+            key = list(help_dict.keys())[-1]
+            last_val = help_dict.get(key)
+            value = last_val + " " + value.strip()
+        help_dict[key.strip()] = value.strip()
+        self.inline_help = help_dict
+
     @staticmethod
     def split_tokens(line):
         """
@@ -352,6 +384,8 @@ class RAlgorithm(QgsProcessingAlgorithm):  # pylint: disable=too-many-public-met
                 if Qgis.QGIS_VERSION_INT >= 31600:
                     if self.descriptions is not None:
                         param.setHelp(self.descriptions.get(param.name()))
+                    elif self.inline_help is not None:
+                        param.setHelp(self.inline_help.get(param.name()))
 
                 self.addParameter(param)
             else:
@@ -822,10 +856,13 @@ class RAlgorithm(QgsProcessingAlgorithm):  # pylint: disable=too-many-public-met
         """
         Returns the algorithms helper string
         """
-        if self.descriptions is None:
-            return ''
+        if self.descriptions is not None:
+            return QgsProcessingUtils.formatHelpMapAsHtml(self.descriptions, self)
 
-        return QgsProcessingUtils.formatHelpMapAsHtml(self.descriptions, self)
+        if self.inline_help is not None:
+            return QgsProcessingUtils.formatHelpMapAsHtml(self.inline_help, self)
+
+        return ''
 
     def tr(self, string, context=''):
         """

--- a/processing_r/test/data/test_algorithm_inline_help.rsx
+++ b/processing_r/test/data/test_algorithm_inline_help.rsx
@@ -1,0 +1,16 @@
+#' ALG_DESC: Test help.
+#' ALG_CREATOR": Me
+#' polyg: A polygon layer description
+#' : from multi-lines
+#' RPLOTS: Plot output
+#' ALG_HELP_CREATOR: Me2}
+##output_plots_to_html
+##load_raster_using_rgdal
+##pass_filenames
+##polyg=vector
+##polyg_category_id=field polyg
+##table_category_id=field sizes_table
+##sampling_size=field sizes_table
+
+
+

--- a/processing_r/test/test_algorithm.py
+++ b/processing_r/test/test_algorithm.py
@@ -514,6 +514,17 @@ class AlgorithmTest(unittest.TestCase):
         alg.initAlgorithm()
         self.assertEqual(alg.shortHelpString(), "")
 
+        alg = RAlgorithm(description_file=os.path.join(test_data_path, 'test_algorithm_inline_help.rsx'))
+        alg.initAlgorithm()
+        self.assertIn('A polygon layer', alg.shortHelpString())
+        self.assertIn('Me2', alg.shortHelpString())
+        self.assertIn('Test help.', alg.shortHelpString())
+
+        # param help
+        if Qgis.QGIS_VERSION_INT >= 31604:
+            polyg_param = alg.parameterDefinition('polyg')
+            self.assertEqual(polyg_param.help(), 'A polygon layer description from multi-lines')
+
     def testAlgDontLoadAnyPackages(self):
         """
         Test dont_load_any_packages keyword

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -16,7 +16,9 @@ theme:
 
 nav:
     - Home: index.md
-    - Script syntax: script-syntax.md
+    - Syntax:
+        - Script Syntax: script-syntax.md
+        - Help Syntax: help-syntax.md
     - Examples:
         - Example with vector output: ex_vector_output.md
         - Example with raster output: ex_raster_output.md

--- a/website/pages/help-syntax.md
+++ b/website/pages/help-syntax.md
@@ -58,8 +58,7 @@ If added to the help file, it will allow for more descriptive information to be 
 
 ## In-line help
  
-As of version 3.2.0 of the plugin, it is also possible to enter the documentation as lines in the same script. lines in the script itself. This makes it possible to dispense with the **.rsx.help** file.  This requires entering lines starting with the characters `#'`. Let's see how the above example should be written.
-
+As of version 3.2.0 of the plugin, it is also possible to enter the documentation as lines in the script itself. This makes it possible to dispense with the **.rsx.help** file. For this purpose, lines with the structure `#' Parameter: Description` must be written. Let's see how the above example should be written.
 ```r
 ##Example scripts=group
 ##Scatterplot=name
@@ -82,4 +81,4 @@ plot(Layer[[X]], Layer[[Y]])
 #' ALG_VERSION: 0.0.1
 ```
 
-Note that this form also allows you to enter the description of a parameter on multiple lines. For which you are required to enter a colon (`:`) after the `#'` characters.
+Note that in this way it is also possible to enter the description of a parameter on several lines. To do this, it is necessary to continue the subsequent lines without entering the parameter name, like this: `#' : description append`.

--- a/website/pages/help-syntax.md
+++ b/website/pages/help-syntax.md
@@ -1,0 +1,85 @@
+# Help syntax
+
+The R scripts for the plugin contain lines of metadata and R commands that perform a procedure. However, it is also possible to add help documentation for the user of that script.
+
+## Help files
+
+The documentation of the script functionalities and its parameters requires an extra file containing the descriptive texts of each input or output parameter. The help file must be located in the same directory and have the name of the script with extension  **.rsx.help**.
+
+The content of this file is a JSON object with the parameter descriptions. For example, suppose we have added a script `"simple_scatterplot.rsx"` with the following content:
+
+```r
+##Example scripts=group
+##Scatterplot=name
+##output_plots_to_html
+##Layer=vector
+##X=Field Layer
+##Y=Field Layer
+
+# simple scatterplot
+plot(Layer[[X]], Layer[[Y]])
+```
+ 
+The help file should be named `"simple_scatterplot.rsx.help"` and its content should be a JSON object as follows:
+
+```json
+{
+"Layer": "Vector Layer",
+"X": "Field from Layer to be used as x-axis variable",
+"Y": "Field from Layer to be used as y-axis variable"
+}
+```
+
+This file can already be used in the script. Parameters that are not described in the help file will be omitted from the help section. Note that each parameter is composed of a pair of `key:value` strings and are separated from other parameters by a comma (,).  
+
+There are special parameters that do not have a user-defined name. These are:
+
+- `"RPLOTS"`, 
+- `"R_CONSOLE_OUTPUT"`, 
+- `"ALG_DESC"`,
+- `"ALG_VERSION"`, 
+- `"ALG_CREATOR"`,
+- `"ALG_HELP_CREATOR"`
+
+If added to the help file, it will allow for more descriptive information to be appended to the script. Continuing with the previous example we can add to the JSON the following information:
+
+```json
+{
+"Layer": "Vector Layer",
+"X": "Field from Layer to be used as x-axis variable",
+"Y": "Field from Layer to be used as y-axis variable",
+"RPLOTS": "Output path for html file with the scatterplot",
+"ALG_DESC": "This file creates a simple scatterplot from two fields in a vector layer",
+"ALG_CREATOR": "Name of algorithm creator",
+"ALG_HELP_CREATOR": "Name of help creator",
+"ALG_VERSION": "0.0.1"
+}
+```
+
+## In-line help
+ 
+As of version 3.2.0 of the plugin, it is also possible to enter the documentation as lines in the same script. lines in the script itself. This makes it possible to dispense with the **.rsx.help** file.  This requires entering lines starting with the characters `#'`. Let's see how the above example should be written.
+
+```r
+##Example scripts=group
+##Scatterplot=name
+##output_plots_to_html
+##Layer=vector
+##X=Field Layer
+##Y=Field Layer
+
+# simple scatterplot
+plot(Layer[[X]], Layer[[Y]])
+
+#' Layer: Vector Layer
+#' X: Field from Layer to be used as x-axis variable
+#' Y: Field from Layer to be used as y-axis variable
+#' RPLOTS: Output path for html file with the scatterplot
+#' ALG_DESC: This file creates a simple scatterplot from 
+#'         : two fields in a vector layer
+#' ALG_CREATOR: Name of algorithm creator
+#' ALG_HELP_CREATOR: Name of help creator
+#' ALG_VERSION: 0.0.1
+```
+
+Note that this form also allows you to enter the description of a parameter on multiple lines. For which you are required to enter a colon (`:`) after the `#'` characters.


### PR DESCRIPTION
Hi guys. Please take a look at this idea. I think it will be useful for easier documentation of R scripts. Let's think of a new parser for lines starting with `#'` that picks up a `parameter:description` string and enters it as Help Texts for parameters and help section. Here is an example script that I have tested on my local host

```r
##Testing help lines=display_name
##Layer=layer
##Field=Field Layer
##output_plots_to_html
>st_dimensions(Layer)
plot(Raster)
#'ALG_DESC: Algorithm description
#'ALG_CREATOR: @gavg712
#'ALG_HELP_CREATOR: @gavg712
#'ALG_VERSION: 0.0.1
#'Layer: Points vector layer.
#'     : This new sentence comes from a new help line within the script
#'Field: Field from "Layer"
#'RPLOTS: File path for output plot
#'R_CONSOLE_OUTPUT: File path for console log
```

This script will not require an extra file `.rsx.help` to display description texts. Can be enough with thus lines starting with `#'`

![image](https://user-images.githubusercontent.com/8514904/142129749-4cd8da20-733f-4ae7-b89f-ba6d2b48776c.png)

The `.rsx.help` files are the primary option, in case of missing file,  help lines will be used. If both are missing, no help is shown.

This is intended for make easy to document R scripts. 
Do you agree?