### PR TITLE
Better capture errors from R in tool log

### DIFF
--- a/processing_r/metadata.txt
+++ b/processing_r/metadata.txt
@@ -10,7 +10,7 @@
 name=Processing R Provider
 qgisMinimumVersion=3.4
 description=A Processing provider for connecting to the R statistics framework
-version=3.1.0
+version=3.1.1
 author=North Road
 email=nyall@north-road.com
 

--- a/processing_r/processing/utils.py
+++ b/processing_r/processing/utils.py
@@ -213,7 +213,7 @@ class RUtils:  # pylint: disable=too-many-public-methods
         """
         Returns True if the given line looks like an error message
         """
-        return any([error in line for error in ['Error ', 'Execution halted']])  # pylint: disable=use-a-generator
+        return any([error in line for error in ['Error ', 'Execution halted', 'Error:']])  # pylint: disable=use-a-generator
 
     @staticmethod
     def get_windows_code_page():

--- a/processing_r/test/test_translations.py
+++ b/processing_r/test/test_translations.py
@@ -28,12 +28,11 @@ class SafeTranslationsTest(unittest.TestCase):
         """Runs before each test."""
         if os.getenv('LANG'):
             del os.environ['LANG']
-            os.environ.__delitem__('LANG')
 
     def tearDown(self):
         """Runs after each test."""
-        if 'LANG' in iter(os.environ.keys()):  # pylint: disable=consider-iterating-dictionary
-            os.environ.__delitem__('LANG')
+        if os.getenv('LANG'):
+            del os.environ['LANG']
 
     def test_qgis_translations(self):
         """Test that translations work."""

--- a/processing_r/test/test_translations.py
+++ b/processing_r/test/test_translations.py
@@ -26,12 +26,12 @@ class SafeTranslationsTest(unittest.TestCase):
 
     def setUp(self):
         """Runs before each test."""
-        if 'LANG' in iter(os.environ.keys()):
+        if 'LANG' in iter(os.environ.keys()):  # pylint: disable=consider-iterating-dictionary
             os.environ.__delitem__('LANG')
 
     def tearDown(self):
         """Runs after each test."""
-        if 'LANG' in iter(os.environ.keys()):
+        if 'LANG' in iter(os.environ.keys()):  # pylint: disable=consider-iterating-dictionary
             os.environ.__delitem__('LANG')
 
     def test_qgis_translations(self):

--- a/processing_r/test/test_translations.py
+++ b/processing_r/test/test_translations.py
@@ -26,7 +26,8 @@ class SafeTranslationsTest(unittest.TestCase):
 
     def setUp(self):
         """Runs before each test."""
-        if 'LANG' in iter(os.environ.keys()):  # pylint: disable=consider-iterating-dictionary
+        if os.getenv('LANG'):
+            del os.environ['LANG']
             os.environ.__delitem__('LANG')
 
     def tearDown(self):

--- a/website/pages/changelog.md
+++ b/website/pages/changelog.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- 3.1.1 Capture correctly even errors from R starting with `Error:`, fix importing `QgsProcessingParameterColor` and `QgsProcessingParameterDateTime` for older QGIS versions (where it is not available)
+
 - 3.0.0 Added support for `QgsProcessingParameter*` strings, that can be used to define script parameters. Better handling of errors in R scripts. New script parameter `##script_title`, that can be used to define string under which the script is listed in QGIS Toolbox.
 
 - 2.3.0 Introduces support for QgsProcessingParameterPoint as an input variable, set parameter help strings under QGIS 3.16 or later


### PR DESCRIPTION
This captures error lines from R that start with `"Error: "`and reports them correctly in tool log. These were previously skipped. This is kinda a standard R error message.

Also updates version in metadata and change log on website with latest changes.

@nyalldawson Can you please merge this and release this version? This will also allow us to close #105, but it was in previous pull request which I merged myself. 

