### PR TITLE
Fix nonreadable layers

### DIFF
--- a/processing_r/metadata.txt
+++ b/processing_r/metadata.txt
@@ -10,7 +10,7 @@
 name=Processing R Provider
 qgisMinimumVersion=3.4
 description=A Processing provider for connecting to the R statistics framework
-version=4.0.0
+version=4.1.0
 author=North Road
 email=nyall@north-road.com
 
@@ -23,7 +23,8 @@ repository=https://github.com/north-road/qgis-processing-r
 # Recommended items:
 
 # Uncomment the following line and add your changelog:
-changelog=4.0.0 Reflect retirement of rgdal R package, only support loading using SF and RASTER packages
+changelog=4.1.0 Fix bugs with layers being converted to SHP messing up field names, version obtaining 
+    4.0.0 Reflect retirement of rgdal R package, only support loading using SF and RASTER packages
     3.1.1 Capture correctly even errors from R starting with `Error:`, fix importing `QgsProcessingParameterColor` and `QgsProcessingParameterDateTime` for older QGIS versions (where it is not available)
     3.1.0 Support "range", "color", "datetime" input parameter types. Fixed list creation from multiple input layer parameters. Fix conversion of custom coordinate reference systems.
     3.0.0 Added support for `QgsProcessingParameter*` strings, that can be used to define script parameters. Better handling of errors in R scripts. New script parameter `##script_title`, that can be used to define string under which the script is listed in QGIS Toolbox.

--- a/processing_r/processing/algorithm.py
+++ b/processing_r/processing/algorithm.py
@@ -569,7 +569,12 @@ class RAlgorithm(QgsProcessingAlgorithm):  # pylint: disable=too-many-public-met
         if Qgis.QGIS_VERSION_INT >= 30900 and hasattr(self, "parameterAsCompatibleSourceLayerPathAndLayerName"):
             # requires qgis 3.10 or later!
             ogr_data_path, layer_name = self.parameterAsCompatibleSourceLayerPathAndLayerName(
-                parameters, name, context, QgsVectorFileWriter.supportedFormatExtensions(), feedback=feedback
+                parameters,
+                name,
+                context,
+                QgsVectorFileWriter.supportedFormatExtensions(),
+                feedback=feedback,
+                preferredFormat="gpkg",
             )
             if layer_name:
                 return self.r_templates.set_variable_vector(name, QDir.fromNativeSeparators(ogr_data_path), layer_name)
@@ -577,7 +582,12 @@ class RAlgorithm(QgsProcessingAlgorithm):  # pylint: disable=too-many-public-met
             return self.r_templates.set_variable_vector(name, QDir.fromNativeSeparators(ogr_data_path))
 
         ogr_data_path = self.parameterAsCompatibleSourceLayerPath(
-            parameters, name, context, QgsVectorFileWriter.supportedFormatExtensions(), feedback=feedback
+            parameters,
+            name,
+            context,
+            QgsVectorFileWriter.supportedFormatExtensions(),
+            feedback=feedback,
+            preferredFormat="gpkg",
         )
         ogr_layer = QgsVectorLayer(ogr_data_path, "", "ogr")
         return self.load_vector_layer_command(name, ogr_layer, feedback)

--- a/processing_r/processing/algorithm.py
+++ b/processing_r/processing/algorithm.py
@@ -68,13 +68,9 @@ from processing_r.processing.r_templates import RTemplates
 from processing_r.processing.utils import RUtils
 
 if Qgis.QGIS_VERSION_INT >= 31000:
-    from qgis.core import (
-        QgsProcessingParameterColor,  # pylint: disable=ungrouped-imports
-    )
+    from qgis.core import QgsProcessingParameterColor  # pylint: disable=ungrouped-imports
 if Qgis.QGIS_VERSION_INT >= 31400:
-    from qgis.core import (
-        QgsProcessingParameterDateTime,  # pylint: disable=ungrouped-imports
-    )
+    from qgis.core import QgsProcessingParameterDateTime  # pylint: disable=ungrouped-imports
 
 
 class RAlgorithm(QgsProcessingAlgorithm):  # pylint: disable=too-many-public-methods

--- a/processing_r/processing/algorithm.py
+++ b/processing_r/processing/algorithm.py
@@ -68,9 +68,13 @@ from processing_r.processing.r_templates import RTemplates
 from processing_r.processing.utils import RUtils
 
 if Qgis.QGIS_VERSION_INT >= 31000:
-    from qgis.core import QgsProcessingParameterColor  # pylint: disable=ungrouped-imports
+    from qgis.core import (
+        QgsProcessingParameterColor,  # pylint: disable=ungrouped-imports
+    )
 if Qgis.QGIS_VERSION_INT >= 31400:
-    from qgis.core import QgsProcessingParameterDateTime  # pylint: disable=ungrouped-imports
+    from qgis.core import (
+        QgsProcessingParameterDateTime,  # pylint: disable=ungrouped-imports
+    )
 
 
 class RAlgorithm(QgsProcessingAlgorithm):  # pylint: disable=too-many-public-methods

--- a/processing_r/processing/utils.py
+++ b/processing_r/processing/utils.py
@@ -427,7 +427,7 @@ def _read_metadata() -> configparser.ConfigParser:
     """
     Read metadata file.
     """
-    path = pathlib.Path(__file__).parent / "metadata.txt"
+    path = pathlib.Path(__file__).parent.parent / "metadata.txt"
 
     config = configparser.ConfigParser()
     config.read(path)

--- a/tests/scripts/test_field_names.rsx
+++ b/tests/scripts/test_field_names.rsx
@@ -1,0 +1,5 @@
+##test long fieldnames=name
+##my group=group
+##Layer=vector
+##fieldname=output string
+fieldname <- fieldnames[length(fieldnames)]

--- a/tests/test_algorithm_inputs.py
+++ b/tests/test_algorithm_inputs.py
@@ -462,3 +462,25 @@ def test_crs():
     # invalid CRS
     script = alg.build_import_commands({"in_crs": QgsCoordinateReferenceSystem("user:4326")}, context, feedback)
     assert "in_crs <- NULL" in script
+
+
+def test_convert_memory_layer_to_gpkg():
+    """
+    Test reading vector inputs
+    """
+    alg = RAlgorithm(description_file=script_path("test_field_names.rsx"))
+    alg.initAlgorithm()
+
+    context = QgsProcessingContext()
+    feedback = QgsProcessingFeedback()
+
+    uri = "point?crs=epsg:4326&field=very_long_fieldname_not_suitable_for_SHP:integer"
+    layer = QgsVectorLayer(uri, "layer", "memory")
+
+    script = alg.build_import_commands({"Layer": layer}, context, feedback)
+
+    first_line = script[0]
+
+    # test that default format is GPKG saved in tmp directory
+    assert first_line.startswith('Layer <- st_read("/tmp')
+    assert first_line.endswith('Layer.gpkg", quiet = TRUE, stringsAsFactors = FALSE)')

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,0 +1,10 @@
+from processing_r.processing.provider import RAlgorithmProvider
+
+
+def test_provider():
+    provider = RAlgorithmProvider()
+
+    assert provider.name() == "R"
+    assert provider.id() == "r"
+    assert provider.versionInfo()
+    assert "QGIS R Provider version " in provider.versionInfo()


### PR DESCRIPTION
Fixes use of SHP format for layers that cannot be read directly. Use GPKG instead which should handle cases like long field names.

Fixes #130 