### PR TITLE
Migrate plugin to QGIS 4 / Qt6

### DIFF
--- a/.github/workflows/test_plugin.yaml
+++ b/.github/workflows/test_plugin.yaml
@@ -26,7 +26,7 @@ jobs:
 
     strategy:
       matrix:
-        docker_tags: [release-3_28, release-3_30, release-3_32, release-3_34, latest]
+        docker_tags: ["4.0", "4.2", latest]
 
     steps:
 

--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,5 @@ venv.bak/
 *.Rproj
 
 processing_r.zip
+
+.claude/

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ LOCALES = af
 # lrelease
 LRELEASE ?= lrelease-qt5
 
-# QGIS3 default
-QGISDIR=.local/share/QGIS/QGIS3/profiles/default
+# QGIS4 default
+QGISDIR=.local/share/QGIS/QGIS4/profiles/default
 
 
 # translation

--- a/processing_r/gui/script_editor/script_editor_dialog.py
+++ b/processing_r/gui/script_editor/script_editor_dialog.py
@@ -31,7 +31,7 @@ import os
 import traceback
 import warnings
 
-from processing.gui.AlgorithmDialog import AlgorithmDialog
+from processing.gui.algorithm_widget import AlgorithmWidget
 from processing.script import ScriptUtils
 from qgis.core import QgsApplication, QgsError, QgsProcessingAlgorithm, QgsProcessingFeatureBasedAlgorithm, QgsSettings
 from qgis.gui import QgsErrorDialog, QgsGui
@@ -140,14 +140,16 @@ class ScriptEditorDialog(BASE, WIDGET):
                 self,
                 self.tr("Save Script?"),
                 self.tr("There are unsaved changes in this script. Do you want to keep those?"),
-                QMessageBox.Save | QMessageBox.Cancel | QMessageBox.Discard,
-                QMessageBox.Cancel,
+                QMessageBox.StandardButton.Save
+                | QMessageBox.StandardButton.Cancel
+                | QMessageBox.StandardButton.Discard,
+                QMessageBox.StandardButton.Cancel,
             )
 
-            if ret == QMessageBox.Save:
+            if ret == QMessageBox.StandardButton.Save:
                 self.saveScript(False)
                 event.accept()
-            elif ret == QMessageBox.Discard:
+            elif ret == QMessageBox.StandardButton.Discard:
                 event.accept()
             else:
                 event.ignore()
@@ -160,10 +162,10 @@ class ScriptEditorDialog(BASE, WIDGET):
                 self,
                 self.tr("Unsaved changes"),
                 self.tr("There are unsaved changes in the script. Continue?"),
-                QMessageBox.Yes | QMessageBox.No,
-                QMessageBox.No,
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.No,
             )
-            if ret == QMessageBox.No:
+            if ret == QMessageBox.StandardButton.No:
                 return
 
         scriptDir = RUtils.default_scripts_folder()
@@ -174,7 +176,7 @@ class ScriptEditorDialog(BASE, WIDGET):
         if fileName == "":
             return
 
-        with OverrideCursor(Qt.WaitCursor):
+        with OverrideCursor(Qt.CursorShape.WaitCursor):
             self._loadFile(fileName)
 
     def save(self):
@@ -227,7 +229,7 @@ class ScriptEditorDialog(BASE, WIDGET):
 
         dlg = alg.createCustomParametersWidget(iface.mainWindow())
         if not dlg:
-            dlg = AlgorithmDialog(alg, parent=iface.mainWindow())
+            dlg = AlgorithmWidget(alg, parent=iface.mainWindow())
 
         canvas = iface.mapCanvas()
         prevMapTool = canvas.mapTool()

--- a/processing_r/gui/script_editor/script_editor_widget.py
+++ b/processing_r/gui/script_editor/script_editor_widget.py
@@ -30,8 +30,7 @@ import os
 from qgis.core import QgsApplication, QgsSettings
 from qgis.PyQt.Qsci import QsciAPIs, QsciLexerPython, QsciScintilla
 from qgis.PyQt.QtCore import Qt
-from qgis.PyQt.QtGui import QColor, QFont, QFontDatabase, QFontMetrics, QKeySequence
-from qgis.PyQt.QtWidgets import QShortcut
+from qgis.PyQt.QtGui import QColor, QFont, QFontDatabase, QFontMetrics, QKeySequence, QShortcut
 
 # This class is ported from the QGIS core Processing script editor.
 # Unfortunately generalising the core editor to allow everything we want in an R editor
@@ -80,11 +79,11 @@ class ScriptEdit(QsciScintilla):
         settings = QgsSettings()
 
         # Default font
-        font = QFontDatabase.systemFont(QFontDatabase.FixedFont)
+        font = QFontDatabase.systemFont(QFontDatabase.SystemFont.FixedFont)
         self.setFont(font)
         self.setMarginsFont(font)
 
-        self.setBraceMatching(QsciScintilla.SloppyBraceMatch)
+        self.setBraceMatching(QsciScintilla.BraceMatch.SloppyBraceMatch)
         self.setMatchedBraceBackgroundColor(
             QColor(
                 settings.value(
@@ -117,7 +116,7 @@ class ScriptEdit(QsciScintilla):
 
         # Show line numbers
         fontmetrics = QFontMetrics(font)
-        self.setMarginWidth(1, fontmetrics.width("0000") + 5)
+        self.setMarginWidth(1, fontmetrics.horizontalAdvance("0000") + 5)
         self.setMarginLineNumbers(1, True)
         self.setMarginsForegroundColor(
             QColor(settings.value("pythonConsole/marginForegroundColorEditor", QColor(self.MARGIN_FOREGROUND_COLOR)))
@@ -146,7 +145,7 @@ class ScriptEdit(QsciScintilla):
         # self.setFoldMarginColors(foldColor, foldColor)
 
         # Mark column 80 with vertical line
-        self.setEdgeMode(QsciScintilla.EdgeLine)
+        self.setEdgeMode(QsciScintilla.EdgeMode.EdgeLine)
         self.setEdgeColumn(80)
         self.setEdgeColor(QColor(settings.value("pythonConsole/edgeColorEditor", QColor(self.EDGE_COLOR))))
 
@@ -175,7 +174,7 @@ class ScriptEdit(QsciScintilla):
         self.defaultFont = QFont(fontName)
         self.defaultFont.setFixedPitch(True)
         self.defaultFont.setPointSize(fontSize)
-        self.defaultFont.setStyleHint(QFont.TypeWriter)
+        self.defaultFont.setStyleHint(QFont.StyleHint.TypeWriter)
         self.defaultFont.setBold(False)
 
         self.boldFont = QFont(self.defaultFont)
@@ -188,7 +187,7 @@ class ScriptEdit(QsciScintilla):
         self.setMarginsFont(self.defaultFont)
 
     def initShortcuts(self):
-        (ctrl, shift) = (self.SCMOD_CTRL << 16, self.SCMOD_SHIFT << 16)
+        ctrl, shift = (self.SCMOD_CTRL << 16, self.SCMOD_SHIFT << 16)
 
         # Disable some shortcuts
         self.SendScintilla(QsciScintilla.SCI_CLEARCMDKEY, ord("D") + ctrl)
@@ -201,9 +200,9 @@ class ScriptEdit(QsciScintilla):
 
         # Use Ctrl+Space for autocompletion
         # no auto complete for R scripts!
-        # self.shortcutAutocomplete = QShortcut(QKeySequence(Qt.CTRL +
-        #                                                   Qt.Key_Space), self)
-        # self.shortcutAutocomplete.setContext(Qt.WidgetShortcut)
+        # self.shortcutAutocomplete = QShortcut(QKeySequence(Qt.Modifier.CTRL |
+        #                                                   Qt.Key.Key_Space), self)
+        # self.shortcutAutocomplete.setContext(Qt.ShortcutContext.WidgetShortcut)
         # self.shortcutAutocomplete.activated.connect(self.autoComplete)
 
     def autoComplete(self):
@@ -213,7 +212,7 @@ class ScriptEdit(QsciScintilla):
         settings = QgsSettings()
         self.lexer = QsciLexerPython()
 
-        font = QFontDatabase.systemFont(QFontDatabase.FixedFont)
+        font = QFontDatabase.systemFont(QFontDatabase.SystemFont.FixedFont)
 
         loadFont = settings.value("pythonConsole/fontfamilytextEditor")
         if loadFont:

--- a/processing_r/metadata.txt
+++ b/processing_r/metadata.txt
@@ -8,9 +8,10 @@
 
 [general]
 name=Processing R Provider
-qgisMinimumVersion=3.4
+qgisMinimumVersion=4.0
+qgisMaximumVersion=4.99
 description=A Processing provider for connecting to the R statistics framework
-version=4.1.0
+version=5.0.0
 author=North Road
 email=nyall@north-road.com
 
@@ -23,7 +24,8 @@ repository=https://github.com/north-road/qgis-processing-r
 # Recommended items:
 
 # Uncomment the following line and add your changelog:
-changelog=4.1.0 Fix bugs with layers being converted to SHP messing up field names, version obtaining 
+changelog=5.0.0 QGIS 4 (Qt6) compatibility; requires QGIS 4.0+
+    4.1.0 Fix bugs with layers being converted to SHP messing up field names, version obtaining 
     4.0.0 Reflect retirement of rgdal R package, only support loading using SF and RASTER packages
     3.1.1 Capture correctly even errors from R starting with `Error:`, fix importing `QgsProcessingParameterColor` and `QgsProcessingParameterDateTime` for older QGIS versions (where it is not available)
     3.1.0 Support "range", "color", "datetime" input parameter types. Fixed list creation from multiple input layer parameters. Fix conversion of custom coordinate reference systems.

--- a/processing_r/processing/actions/delete_script.py
+++ b/processing_r/processing/actions/delete_script.py
@@ -60,10 +60,10 @@ class DeleteScriptAction(ContextAction):
             None,
             self.tr("Delete Script"),
             self.tr("Are you sure you want to delete this script?"),
-            QMessageBox.Yes | QMessageBox.No,
-            QMessageBox.No,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
         )
-        if reply == QMessageBox.Yes:
+        if reply == QMessageBox.StandardButton.Yes:
             file_path = self.itemData.description_file
             if file_path is not None:
                 os.remove(file_path)

--- a/processing_r/processing/r_templates.py
+++ b/processing_r/processing/r_templates.py
@@ -530,7 +530,7 @@ class RTemplates:  # pylint: disable=too-many-public-methods
         :param datetime: QDateTime. Red, green, blue and alpha values.
         :return: string. R code that constructs the color hex string.
         """
-        dtt = datetime.toString(format=Qt.ISODate)
+        dtt = datetime.toString(format=Qt.DateFormat.ISODate)
         commands = []
         commands.append('{0} <- as.POSIXct("{1}", format = "%Y-%m-%dT%H:%M:%S")'.format(variable, dtt))
 
@@ -541,7 +541,7 @@ class RTemplates:  # pylint: disable=too-many-public-methods
         Generate R string.
         """
 
-        datetime = datetime.toString(format=Qt.ISODate)
+        datetime = datetime.toString(format=Qt.DateFormat.ISODate)
 
         return 'as.POSIXct("{}", format = "%Y-%m-%dT%H:%M:%S")'.format(datetime)
 
@@ -561,7 +561,7 @@ class RTemplates:  # pylint: disable=too-many-public-methods
         Generate R string.
         """
 
-        date = date.toString(format=Qt.ISODate)
+        date = date.toString(format=Qt.DateFormat.ISODate)
 
         return 'as.POSIXct("{}", format = "%Y-%m-%d")'.format(date)
 
@@ -583,7 +583,7 @@ class RTemplates:  # pylint: disable=too-many-public-methods
 
         self._use_lubridate = True
 
-        return 'lubridate::hms("{}")'.format(time.toString(Qt.TextDate))
+        return 'lubridate::hms("{}")'.format(time.toString(Qt.DateFormat.TextDate))
 
     def set_variable_list(self, variable: str, values_list: List[Any]) -> Any:
         """

--- a/processing_r/r_plugin.py
+++ b/processing_r/r_plugin.py
@@ -18,7 +18,10 @@ import os
 from qgis.core import QgsApplication
 from qgis.gui import QgisInterface
 from qgis.PyQt.QtCore import QCoreApplication, QTranslator
+from qgis.PyQt.QtGui import QAction
 
+from processing_r.gui.gui_utils import GuiUtils
+from processing_r.processing.actions.create_new_script import CreateNewScriptAction
 from processing_r.processing.provider import RAlgorithmProvider
 
 
@@ -73,6 +76,19 @@ class RProviderPlugin:
         """Creates application GUI widgets"""
         self.initProcessing()
 
+        # Processing's own "create new script" toolbar button for this provider relies on
+        # QgsProcessingRegistry.providerAdded, which some QGIS builds fail to wire up for
+        # providers registered after the Processing Toolbox panel is constructed (i.e. any
+        # provider added by a plugin, as opposed to a core provider). Expose the same action
+        # from the Plugins menu too, so script creation doesn't depend on that panel's timing.
+        self.new_script_action_handler = CreateNewScriptAction()
+        self.new_script_action = QAction(
+            GuiUtils.get_icon("providerR.svg"), self.tr("Create New R Script…"), self.iface.mainWindow()
+        )
+        self.new_script_action.triggered.connect(self.new_script_action_handler.execute)
+        self.iface.addPluginToMenu(self.tr("Processing R Provider"), self.new_script_action)
+
     def unload(self):
         """Removes the plugin menu item and icon from QGIS GUI."""
         QgsApplication.processingRegistry().removeProvider(self.provider)
+        self.iface.removePluginMenu(self.tr("Processing R Provider"), self.new_script_action)


### PR DESCRIPTION
## Summary

- Scopes bare Qt enums that Qt6 requires qualified (`Qt.ISODate` → `Qt.DateFormat.ISODate`, `QMessageBox.Yes` → `QMessageBox.StandardButton.Yes`, `QFont.TypeWriter` → `QFont.StyleHint.TypeWriter`, etc.) and fixes two other Qt5→Qt6 breaks: `QShortcut` moved `QtWidgets` → `QtGui`, and `QFontMetrics.width()` was removed in favor of `horizontalAdvance()`.
- Fixes the script editor's "Run" action, which imported `processing.gui.AlgorithmDialog` — QGIS 4 renamed this to `processing.gui.algorithm_widget.AlgorithmWidget`. This only surfaces at runtime (not caught by static Qt6 scanners), found by actually running the migrated plugin under QGIS 4.2.
- Adds a "Create New R Script…" entry under the Plugins menu, independent of the Processing Toolbox's per-provider toolbar button.
- Bumps `qgisMinimumVersion` to `4.0` (dropping Qt5/QGIS3 support) and sets `qgisMaximumVersion=4.99`; updates the Makefile's manual deploy path and the CI Docker image matrix to match.

## Note for maintainers

While testing, I found that the "Create New R Script…" toolbar button (registered via `ProviderActions`, same mechanism Python/Models scripts use) doesn't appear in QGIS 4.2's Processing Toolbox panel. Root cause is upstream, in QGIS core's `processing/gui/ProcessingToolbox.py`:

```python
QgsApplication.processingRegistry().providerRemoved.connect(self.addProvider)
QgsApplication.processingRegistry().providerRemoved.connect(self.removeProvider)
```

Both handlers are wired to `providerRemoved`; `providerAdded` (which exists on `QgsProcessingRegistry`) is never connected to `self.addProvider`. The toolbox only builds provider toolbar buttons once, in `__init__`, for providers already registered at that moment — core providers like Python/Models qualify, but any provider a plugin registers afterward (ours included) never gets its button. This isn't specific to this plugin and is worth reporting against QGIS core; I haven't done so myself. The new Plugins-menu entry in this PR works around it without depending on a core fix.

## Test plan

- [x] `scripts/check_qt6_migration.py` (QGIS4 plugin-dev skill's Qt6 pattern scanner): 0 issues
- [x] `python3 -m compileall processing_r`: clean
- [x] `black --check processing_r`: clean
- [x] Ran the plugin under QGIS 4.2.0 (Qt 6.11.1): all modules import, script editor widget instantiates (exercises every scoped-enum fix), date/time R-code generation produces correct output, provider registers, new Plugins-menu action opens the script editor
- [x] CI (QGIS 4.0/4.2/latest Docker matrix) — will run on this PR
- [ ] Maintainer smoke test on Windows/Linux recommended before merge, since local testing was macOS-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)